### PR TITLE
Wait for page unload to reset zoom animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,6 @@
         doorImg.src = doorImg.src.replace('door_', 'door_open_');
         window.setTimeout(() => {
           window.onunload = () => {
-            console.log("fire");
             zoom.classList.remove('active');
             cssAnim.remove();
             doorImg.src = doorImg.src.replace('_open', '');

--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
             // wait for document to be hidden
             // must be done here to not respond to switching tabs
             window.onpagehide = null;
-            document.onvisibilitychange = (event) => {
+            document.onvisibilitychange = () => {
               // make sure the document is being hidden
               if (document.visibilityState != 'hidden') return;
               document.onvisibilitychange = null;

--- a/index.html
+++ b/index.html
@@ -205,11 +205,12 @@
         const doorImg = door.querySelector('.doorImg');
         doorImg.src = doorImg.src.replace('door_', 'door_open_');
         window.setTimeout(() => {
-          window.onunload = () => {
+          window.onpagehide = () => {
             zoom.classList.remove('active');
             cssAnim.remove();
             doorImg.src = doorImg.src.replace('_open', '');
             door.classList.remove('active');
+            window.onpagehide = null;
           };
           window.location.href = `/${gameId}/`;
         }, 1500);

--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
             window.onpagehide = null;
             document.onvisibilitychange = (event) => {
               // make sure the document is being hidden
-              if (document.visibilityState != "hidden") return;
+              if (document.visibilityState != 'hidden') return;
               document.onvisibilitychange = null;
               zoom.classList.remove('active');
               cssAnim.remove();

--- a/index.html
+++ b/index.html
@@ -205,12 +205,13 @@
         const doorImg = door.querySelector('.doorImg');
         doorImg.src = doorImg.src.replace('door_', 'door_open_');
         window.setTimeout(() => {
-          window.setTimeout(() => {
+          window.onunload = () => {
+            console.log("fire");
             zoom.classList.remove('active');
             cssAnim.remove();
             doorImg.src = doorImg.src.replace('_open', '');
             door.classList.remove('active');
-          }, 100);
+          };
           window.location.href = `/${gameId}/`;
         }, 1500);
       }, 1000);

--- a/index.html
+++ b/index.html
@@ -205,12 +205,20 @@
         const doorImg = door.querySelector('.doorImg');
         doorImg.src = doorImg.src.replace('door_', 'door_open_');
         window.setTimeout(() => {
+          // wait for page navigation
           window.onpagehide = () => {
-            zoom.classList.remove('active');
-            cssAnim.remove();
-            doorImg.src = doorImg.src.replace('_open', '');
-            door.classList.remove('active');
+            // wait for document to be hidden
+            // must be done here to not respond to switching tabs
             window.onpagehide = null;
+            document.onvisibilitychange = (event) => {
+              // make sure the document is being hidden
+              if (document.visibilityState != "hidden") return;
+              document.onvisibilitychange = null;
+              zoom.classList.remove('active');
+              cssAnim.remove();
+              doorImg.src = doorImg.src.replace('_open', '');
+              door.classList.remove('active');
+            };
           };
           window.location.href = `/${gameId}/`;
         }, 1500);


### PR DESCRIPTION
On slower computers/browsers, the zoom CSS animation would be reset before the page switched. This changes it so that it waits until the page actually begins to unload and isn't visible before resetting.

This should be compatible with back/forward navigation caching (if any web browser can do that for YNOProject's pages).